### PR TITLE
Add webpack v4 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,9 @@ module.exports = function(content) {
 
   const config = Object.assign(defaultConfig, loaderUtils.getOptions(this));
 
+  const context = this.options ? this.options.context : this.rootContext;
   const fileName = loaderUtils.interpolateName(this, config.name, {
-    context: this.options.context,
+    context: context,
     content: content
   });
 


### PR DESCRIPTION
@smt116 
Hello.
I'm thankful for this good module!
But, unfortunately, this module doesn't work with webpack v4.

On webpack v4, it have been changed `this.options.context` to `this.rootContext`.
https://github.com/webpack/webpack/blob/6a5d081f294a225d9f02b56c55fdcd61b7b4db20/lib/NormalModule.js#L168
https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202

I modified that it is assumed if `this.options` existed is older v3, not existed is v4.
Regards.