### PR TITLE
correctly handle "./" rewritePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,10 @@ module.exports = function (content) {
 
   if (config.rewritePath) {
     let filePath;
-    if (config.rewritePath === './') {
+    // path.join will remove ./ but it might important in some project configuration (electron)
+    // so we handle it separately
+    //support both windows and unix way of defining current directory
+    if (config.rewritePath === './'  || config.rewritePath === '.\') {
       filePath = JSON.stringify(config.rewritePath + fileName);
     } else {
       filePath = JSON.stringify(path.join(config.rewritePath, fileName));

--- a/index.js
+++ b/index.js
@@ -16,7 +16,12 @@ module.exports = function (content) {
   }
 
   if (config.rewritePath) {
-    const filePath = JSON.stringify(path.join(config.rewritePath, fileName));
+    let filePath;
+    if (config.rewritePath === './') {
+      filePath = JSON.stringify(config.rewritePath + fileName);
+    } else {
+      filePath = JSON.stringify(path.join(config.rewritePath, fileName));
+    }
 
     return "try { global.process.dlopen(module, " + filePath + "); } " +
       "catch(exception) { throw new Error('Cannot open ' + " + filePath + " + ': ' + exception); };";

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (content) {
     // path.join will remove ./ but it might important in some project configuration (electron)
     // so we handle it separately
     //support both windows and unix way of defining current directory
-    if (config.rewritePath === './'  || config.rewritePath === '.\') {
+    if (config.rewritePath === './' || config.rewritePath === '.\\') {
       filePath = JSON.stringify(config.rewritePath + fileName);
     } else {
       filePath = JSON.stringify(path.join(config.rewritePath, fileName));


### PR DESCRIPTION
I needed this because i could not rely on __dirname.
When using webpack the __dirname will be the folder of the .node within the node_modules folder.
But the .node file is copied alongside the bundle.js file.
Using ./ works though.