### PR TITLE
Add `emit` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ It allows to set an absolute paths to native files.
 
 Note that it needs to remain `undefined` if you are building a package with embedded files. This way, the compiled application will work no matter of its location. This is important when building Electron applications that can be placed in any directory by the end user.
 
+### `emit` (default: `true`)
+
+Specifies whether the imported `.node` file will be copied to the output directory.
+
 ## Releasing a new version
 
 1.  Bump version number in the `package.json` and `CHANGELOG.md` files.

--- a/index.js
+++ b/index.js
@@ -3,18 +3,22 @@ var path = require("path");
 module.exports = function(content) {
   const defaultConfig = {
     basePath: [],
-    rewritePath: undefined
+    rewritePath: undefined,
+    emit: true
   };
 
   const config = Object.assign(defaultConfig, this.query);
   const fileName = path.basename(this.resourcePath);
 
-  if (this.emitFile) {
-    this.emitFile(fileName, content, false);
-    this.addDependency(this.resourcePath);
-  } else {
-    throw new Error("emitFile function is not available");
+  if (config.emit) {
+    if (this.emitFile) {
+      this.emitFile(fileName, content, false);
+    } else {
+      throw new Error("emitFile function is not available");
+    }
   }
+  
+  this.addDependency(this.resourcePath);
 
   if (config.rewritePath) {
     let filePath;


### PR DESCRIPTION
Allows controlling whether the `.node` files are copied to the output directory.

I'm currently having trouble with builds in watch mode on an electron app, where I have native additions. When the electron app is already running and I make changes, this plugin will try to re-emit the native addon file and crash the build.
So I figured since the native addons don't change while I'm running the watch mode build, I could just disable the emit from here and do the copying in a single step upfront.

I hope this is an ok addition in your mind, it would be much more convenient to have this in the main package instead of using my own fork